### PR TITLE
Added functionality to parse code blocks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,21 @@ Example c header.h
 
 .. include-comment:: ../README.rst
 
+And to include whole code blocks without retyping them you may use the following syntax:
+
+.. code-block:: c   
+
+
+    /**
+      Comment for the following code block
+      .. code-block:: c 
+      \code 
+    */
+    code_to_showcase();
+    /**
+      \endcode
+    */
+
 
 Configuration
 -------------


### PR DESCRIPTION
Hi there,

Thank you for your work!

I added some functionality to actually include some code blocks without the need to double type the text every time (and to prevent a documentation to be out of sync to the actual code).
I could not find such a feature in sphynx or your extension, if there is already such a feature please tell me!

Before:
```
	/**
	Comment for the following code block

	.. code-block:: c

	   code_to_showcase();
	*/
	   code_to_showcase();
```
Now:
```
	/**
	Comment for the following code block

	.. code-block:: c 
	\code 
	*/
	   code_to_showcase();
        /**

	 \endcode

	 */
```
