### PR TITLE
rework based upon include command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,13 +86,13 @@ Example c header.h
     typedef struct my_struct_s
     {
         int id;
-        struct timeval t; 
+        struct timeval t;
         void *value;
      }  my_struct_t;
 
     /**
      .. c:function:: my_struct_t * connect(my_struct_t * m, const char *url)
- 
+
      Connect the client to the server given by *url*.
 
     */
@@ -102,24 +102,53 @@ Example c header.h
 
 And to include whole code blocks without retyping them you may use the following syntax:
 
-.. code-block:: c   
+.. code-block:: c
 
 
     /**
       Comment for the following code block
-      .. code-block:: c 
-      \code 
+      .. code-block:: c
+      \code
     */
     code_to_showcase();
     /**
       \endcode
     */
 
+  or
+
+  .. code-block:: c
+
+
+      /**
+        Comment for the following code block
+        .. code-block:: c
+        \multicomment
+      */
+      code_to_showcase();
+      /**
+        \end_multicomment
+      */
+
+Every comment block "/** ... */" will be suffixed with a new line.
+
+If you do whish to have a more direct control over the identation
+you may use the * character as virtual line start
+.. code-block:: c
+
+
+    /**
+      This line will be on root level
+     *  this line has a identation of 2
+    */
+
+If you do want to keep the identation of your comments as is
+you may use the \\toggle_keepwhitespaces command in your included file.
 
 Configuration
 -------------
 
-None so far.
+The same as the Include Directive of Sphinx (http://docutils.sourceforge.net/docs/ref/rst/directives.html#include)
 
 TODO
 ====

--- a/sphinxcontrib/cmtinc.py
+++ b/sphinxcontrib/cmtinc.py
@@ -11,175 +11,232 @@
     :license: MIT, see LICENSE for details
 """
 
-import posixpath
-import codecs
+import sys
+import os.path
 import re
-from os import path
-from docutils import nodes
-from sphinx.util.nodes import nested_parse_with_titles
+import time
+from docutils import io, nodes, statemachine, utils
+from docutils.utils.error_reporting import SafeString, ErrorString
+from docutils.utils.error_reporting import locale_encoding
+from docutils.parsers.rst import Directive, convert_directive_function
+from docutils.parsers.rst import directives, roles, states
+from docutils.parsers.rst.directives.body import CodeBlock, NumberLines
+from docutils.parsers.rst.roles import set_classes
+from docutils.transforms import misc
 from docutils.statemachine import ViewList
-from docutils.parsers.rst import directives
-from sphinx.util.compat import Directive
 
-re_comment = re.compile("^\s?/\*\*\**(.*)$")
-re_cmtnext = re.compile("^[/\* | \*]?\**(.*)$")
-re_cmtend = re.compile("(.*)(\*/)+$")
+re_multilinecomment = re.compile("^\s*\/\*\*.*$")
+re_multilinecomment_end = re.compile("(.*)\*\/\ *$")
+re_whitespace_content = re.compile("^\s*(?:\*|#|(?:\/\/))?(\s*.*)$")
 
-class ExtractError(Exception):
-    pass
+class IncludeComments(Directive):
 
-class Extractor(object):
     """
-    Main extraction class
+    Include content read from a separate source file.
+
+    Content may be parsed by the parser, or included as a literal
+    block.  The encoding of the included file can be specified.  Only
+    a part of the given file argument may be included by specifying
+    start and end line or text to match before and/or after the text
+    to be used.
+
+    based on the Include Directives at  http://svn.code.sf.net/p/docutils/code/trunk/docutils/docutils/parsers/rst/directives/misc.py
+    and https://github.com/sphinx-doc/sphinx/blob/master/sphinx/directives/other.py
     """
-    def __init__(self):
-        """
-        """
-        self.content = ViewList("",'comment')
-        self.lineno = 0
-        self.is_multiline = False;
 
-    def extract(self, source):
-        """
-        Process the source file and fill in the content.
-        SOURCE is a fileobject.
-        """
-        for l in source:
-            self.lineno = self.lineno + 1
-            l = l.strip()
-            m = re_comment.match(l)
-
-            if (m):
-                self.comment(m.group(1), source)
-
-
-    def comment(self, cur, source):
-        """
-        Read the whole comment and strip the stars.
-
-        CUR is currently read line and SOURCE is a fileobject
-        with the source code.
-        """
-        self.content.append(cur.strip(), "comment")
-
-        for line in source:
-            self.lineno = self.lineno + 1
-            line = line.strip()
-
-            if re_cmtend.match(line):
-                if (not self.is_multiline):
-                    break
-                else:
-                    continue;
-
-            if line.startswith("/*"):
-                if (not self.is_multiline):
-                    raise ExtractError("%d: Nested comments are not supported yet." % self.lineno)
-                else:
-                    continue;
-
-            if line.startswith(".. "):
-                self.content.append(line, "comment")
-                continue
-
-            if line.startswith("\code"):
-                self.is_multiline = True
-                continue
-
-            if line.startswith("\endcode"):
-                self.is_multiline = False
-                continue
-
-            if line.startswith("/"):
-                line = "/" + line
-
-            m = re_cmtnext.match(line)
-            if m:
-                self.content.append("    " + m.group(1).strip(), "comment")
-                continue
-
-            self.content.append(line.strip(), "comment")
-
-
-        self.content.append('\n', "comment")
-
-
-class CmtIncDirective(Directive):
-    """
-    Directive to insert comments form source file.
-    """
-    has_content = True
     required_arguments = 1
     optional_arguments = 0
-    final_argument_whitespace = False
-    option_spec = { }
+    final_argument_whitespace = True
+    option_spec = {'literal': directives.flag,
+                   'code': directives.unchanged,
+                   'encoding': directives.encoding,
+                   'tab-width': int,
+                   'start-line': int,
+                   'end-line': int,
+                   'start-after': directives.unchanged_required,
+                   'end-before': directives.unchanged_required,
+                   # ignored except for 'literal' or 'code':
+                   'number-lines': directives.unchanged, # integer or None
+                   'class': directives.class_option,
+                   'name': directives.unchanged}
+
+    standard_include_path = os.path.join(os.path.dirname(states.__file__),
+                                         'include')
+
+    def filterText(self, rawtext):
+        includeLine = 0
+        filterdText =  ViewList("",'comment')
+        identationfactor = 0
+        keepwhitespaces = False
+        for line in rawtext.split('\n'):
+            ignoreLine = False;
+
+            m = re_multilinecomment.match(line)
+            if(m):
+                includeLine +=1
+                ignoreLine = True;
+
+            if (includeLine > 0):
+                if("\\toggle_keepwhitespaces" in line):
+                    ignoreLine = True
+                    keepwhitespaces = not keepwhitespaces
+
+                if (any(tag in line for tag in
+                        ["\code", "\multicomment"])):
+                   includeLine +=1
+                   identationfactor += 1
+                   ignoreLine = True;
+
+                if (any(tag in line for tag in
+                        ["\endcode", "\end_multicomment"])):
+                   includeLine -=1
+                   identationfactor -= 1
+                   ignoreLine = True;
+
+            m = re_multilinecomment_end.match(line)
+            if(m and includeLine > 0):
+                filterdText.append('\n','comment')
+                includeLine -=1
+                ignoreLine = True;
+
+            if (not ignoreLine and includeLine > 0):
+                if (identationfactor <= 0 and not keepwhitespaces):
+                    linecontent = re_whitespace_content.match(line).group(1)
+                    filterdText.append('%s\n' % (linecontent),'comment')
+                else:
+                    filterdText.append('%s%s\n' % ((' ' * identationfactor), line),'comment')
+            #else:
+                #filterdText.append( 'D%d %s%s\n' % (includeLine, identation, line),'comment')
+        if (includeLine != 0):
+            raise self.severe("Comments may not be closed correctly! Open comments: %d" % (includeLine))
+
+        return ''.join(filterdText)
 
     def run(self):
-        """Run it """
-        self.reporter = self.state.document.reporter
-        self.env = self.state.document.settings.env
-        if self.arguments:
-            if self.content:
-                return [self.reporter.warning(
-                    'include-comment directive cannot have content only '
-                    'a filename argument', line=self.lineno)]
-            rel_filename, filename = self.env.relfn2path(self.arguments[0])
-            self.env.note_dependency(rel_filename)
+        """Include a file as part of the content of this reST file."""
 
-            extr = Extractor()
-            f = None
-            try:
-                encoding = self.options.get('encoding',
-                                            self.env.config.source_encoding)
-                codecinfo = codecs.lookup(encoding)
-                f = codecs.StreamReaderWriter(
-                    open(filename, 'rb'), codecinfo[2], codecinfo[3], 'strict')
-                extr.extract(f)
-            except (IOError, OSError):
-                return [self.reporter.warning(
-                    'Include file %r not found or reading it failed' % filename,
-                    line=self.lineno)]
-            except UnicodeError:
-                return [self.reporter.warning(
-                    'Encoding %r used for reading included file %r seems to '
-                    'be wrong, try giving an :encoding: option' %
-                    (encoding, filename))]
-            except ExtractError as e:
-                return [self.reporter.warning(
-                    'Parsing error in %s : %s' %(filename, str(e)),
-                    line=self.lineno)]
-            finally:
-                if f is not None:
-                    f.close()
-            self.content = extr.content
-            self.content_offset = 0
-            # Create a node, to be populated by `nested_parse`.
-            node = nodes.paragraph()
-            # Parse the directive contents.
-            nested_parse_with_titles(self.state, self.content, node)
-            return node.children
-        else:
-            return [self.reporter.warning(
-                'include-comment directive needs a filename argument',
-                line=self.lineno)]
+        # from sphynx Include Directive in https://github.com/sphinx-doc/sphinx/blob/master/sphinx/directives/other.py
+        # type: () -> List[nodes.Node]
+        env = self.state.document.settings.env
+        if self.arguments[0].startswith('<') and \
+           self.arguments[0].endswith('>'):
+            # docutils "standard" includes, do not do path processing
+            return BaseInclude.run(self)
+        rel_filename, filename = env.relfn2path(self.arguments[0])
+        self.arguments[0] = filename
+        env.note_included(filename)
+        #end
+
+        if not self.state.document.settings.file_insertion_enabled:
+            raise self.warning('"%s" directive disabled.' % self.name)
+        source = self.state_machine.input_lines.source(
+            self.lineno - self.state_machine.input_offset - 1)
+        source_dir = os.path.dirname(os.path.abspath(source))
+        path = directives.path(self.arguments[0])
+        if path.startswith('<') and path.endswith('>'):
+            path = os.path.join(self.standard_include_path, path[1:-1])
+        path = os.path.normpath(os.path.join(source_dir, path))
+        path = utils.relative_path(None, path)
+        path = nodes.reprunicode(path)
+        encoding = self.options.get(
+            'encoding', self.state.document.settings.input_encoding)
+        e_handler=self.state.document.settings.input_encoding_error_handler
+        tab_width = self.options.get(
+            'tab-width', self.state.document.settings.tab_width)
+        try:
+            self.state.document.settings.record_dependencies.add(path)
+            include_file = io.FileInput(source_path=path,
+                                        encoding=encoding,
+                                        error_handler=e_handler)
+        except UnicodeEncodeError, error:
+            raise self.severe(u'Problems with "%s" directive path:\n'
+                              'Cannot encode input file path "%s" '
+                              '(wrong locale?).' %
+                              (self.name, SafeString(path)))
+        except IOError, error:
+            raise self.severe(u'Problems with "%s" directive path:\n%s.' %
+                      (self.name, ErrorString(error)))
+        startline = self.options.get('start-line', None)
+        endline = self.options.get('end-line', None)
+        try:
+            if startline or (endline is not None):
+                lines = include_file.readlines()
+                rawtext = ''.join(lines[startline:endline])
+            else:
+                rawtext = include_file.read()
+        except UnicodeError, error:
+            raise self.severe(u'Problem with "%s" directive:\n%s' %
+                              (self.name, ErrorString(error)))
+        # start-after/end-before: no restrictions on newlines in match-text,
+        # and no restrictions on matching inside lines vs. line boundaries
+        after_text = self.options.get('start-after', None)
+        if after_text:
+            # skip content in rawtext before *and incl.* a matching text
+            after_index = rawtext.find(after_text)
+            if after_index < 0:
+                raise self.severe('Problem with "start-after" option of "%s" '
+                                  'directive:\nText not found.' % self.name)
+            rawtext = rawtext[after_index + len(after_text):]
+        before_text = self.options.get('end-before', None)
+        if before_text:
+            # skip content in rawtext after *and incl.* a matching text
+            before_index = rawtext.find(before_text)
+            if before_index < 0:
+                raise self.severe('Problem with "end-before" option of "%s" '
+                                  'directive:\nText not found.' % self.name)
+            rawtext = rawtext[:before_index]
+
+        rawtext = self.filterText(rawtext)
+        #if (path == "../examples/neuropil_hydra.c"):
+            #raise self.severe('filterd text from %s:\n%s' % (path, rawtext))
+
+        include_lines = statemachine.string2lines(rawtext, tab_width,
+                                                  convert_whitespace=True)
+        if 'literal' in self.options:
+            # Convert tabs to spaces, if `tab_width` is positive.
+            if tab_width >= 0:
+                text = rawtext.expandtabs(tab_width)
+            else:
+                text = rawtext
+            literal_block = nodes.literal_block(rawtext, source=path,
+                                    classes=self.options.get('class', []))
+            literal_block.line = 1
+            self.add_name(literal_block)
+            if 'number-lines' in self.options:
+                try:
+                    startline = int(self.options['number-lines'] or 1)
+                except ValueError:
+                    raise self.error(':number-lines: with non-integer '
+                                     'start value')
+                endline = startline + len(include_lines)
+                if text.endswith('\n'):
+                    text = text[:-1]
+                tokens = NumberLines([([], text)], startline, endline)
+                for classes, value in tokens:
+                    if classes:
+                        literal_block += nodes.inline(value, value,
+                                                      classes=classes)
+                    else:
+                        literal_block += nodes.Text(value, value)
+            else:
+                literal_block += nodes.Text(text, text)
+            return [literal_block]
+        if 'code' in self.options:
+            self.options['source'] = path
+            codeblock = CodeBlock(self.name,
+                                  [self.options.pop('code')], # arguments
+                                  self.options,
+                                  include_lines, # content
+                                  self.lineno,
+                                  self.content_offset,
+                                  self.block_text,
+                                  self.state,
+                                  self.state_machine)
+            return codeblock.run()
+
+        self.state_machine.insert_input(include_lines, path)
+        return []
+
 
 def setup(app):
-    app.add_directive('include-comment', CmtIncDirective)
-
-
-if __name__ == '__main__':
-    import sys
-
-    if len(sys.argv) < 2:
-        print("Usage: cmtinc.py <file.c|cpp|h>")
-        exit(1)
-
-    ext = Extractor()
-    try:
-        with open(sys.argv[1], 'r') as f:
-            ext.extract(f)
-    except ExtractError as e:
-        print('Extraction error in external source file %r : %s'
-                    % (sys.argv[1], str(e)))
-    for line in ext.content:
-        print(line)
+    app.add_directive('include-comment', IncludeComments)

--- a/sphinxcontrib/cmtinc.py
+++ b/sphinxcontrib/cmtinc.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 """
     sphinxcontrib.cmtinc
@@ -148,12 +149,12 @@ class IncludeComments(Directive):
             include_file = io.FileInput(source_path=path,
                                         encoding=encoding,
                                         error_handler=e_handler)
-        except UnicodeEncodeError, error:
+        except UnicodeEncodeError as error:
             raise self.severe(u'Problems with "%s" directive path:\n'
                               'Cannot encode input file path "%s" '
                               '(wrong locale?).' %
                               (self.name, SafeString(path)))
-        except IOError, error:
+        except IOError as error:
             raise self.severe(u'Problems with "%s" directive path:\n%s.' %
                       (self.name, ErrorString(error)))
         startline = self.options.get('start-line', None)
@@ -164,7 +165,7 @@ class IncludeComments(Directive):
                 rawtext = ''.join(lines[startline:endline])
             else:
                 rawtext = include_file.read()
-        except UnicodeError, error:
+        except UnicodeError as error:
             raise self.severe(u'Problem with "%s" directive:\n%s' %
                               (self.name, ErrorString(error)))
         # start-after/end-before: no restrictions on newlines in match-text,


### PR DESCRIPTION
Hi there

i did rework the plugin code based upon the include command from sphinx.
( http://svn.code.sf.net/p/docutils/code/trunk/docutils/docutils/parsers/rst/directives/misc.py
and https://github.com/sphinx-doc/sphinx/blob/master/sphinx/directives/other.py )
This allows some better control over the indentation etc. and has some _buildin_ (better: copy pasted, as inheritance was not possible) features.

I don't know if I should publish it as new plugin or if you do want to update the original repository with it (as it still shares the same command and use-case).

Kind Regards
 Simon