### PR TITLE
Add alternate #-style commenting

### DIFF
--- a/sphinxcontrib/cmtinc.py
+++ b/sphinxcontrib/cmtinc.py
@@ -93,13 +93,12 @@ class IncludeComments(Directive):
                     ignoreLine = True
                     keepwhitespaces = not keepwhitespaces
 
-                if (any(tag in line for tag in
-                        ["\code", "\multicomment"])):
+                match_code_tag = re.search(r'(?P<whitespace>\s*)\\(?P<tag>code|multicomment)', line)
+                if match_code_tag:
                    includeLine +=1
                    ignoreLine = True;
 
-                   match_whitespace = re.match('^\s*', line)
-                   leading_whitespace = len(match_whitespace.group(0)) if match_whitespace else 0
+                   leading_whitespace = len(match_code_tag.group('whitespace'))
                    identationstack.append(leading_whitespace)
 
 

--- a/sphinxcontrib/cmtinc.py
+++ b/sphinxcontrib/cmtinc.py
@@ -33,8 +33,8 @@ COMMENT_STYLES = {
             'whitespace_content': re.compile("^\s*(?:\*|#|(?:\/\/))?(\s*.*)$"),
             },
         'hash': {
-            'multiline': re.compile("^#:.*$"),
-            'multiline_end': re.compile("^#\..*$"),
+            'multiline': re.compile("^\s*(#:).*$"),
+            'multiline_end': re.compile("^\s*(#\.).*$"),
             'whitespace_content': re.compile("^\s*(?:# )?(\s*.*)$"),
             },
         }

--- a/sphinxcontrib/cmtinc.py
+++ b/sphinxcontrib/cmtinc.py
@@ -35,7 +35,7 @@ COMMENT_STYLES = {
         'hash': {
             'multiline': re.compile("^\s*(#:).*$"),
             'multiline_end': re.compile("^\s*(#\.).*$"),
-            'whitespace_content': re.compile("^\s*(?:# )?(\s*.*)$"),
+            'whitespace_content': re.compile("^\s*(?:# ?)?(\s*.*)$"),
             },
         }
 


### PR DESCRIPTION
This commit adds a 'style' option which allows the caller to choose from
a list of pre-defined styles for comments to be parsed from the target
file. The default for this option is 'C-style', which selects the same
behavior as this extension has provided to date.

Additionally, this adds a 'hash' style option, which extracts comments
of the following format, intended for Ansible (or YAML, generally)
files.

```
  #:
  # This is a sample comment which would be selected with the 'hash'
  # style option.
  #.
  - name: An Ansible Task
    ...
```